### PR TITLE
small ITCStorage obj term name change for better testing

### DIFF
--- a/src/types/policies/ITCStorage.jl
+++ b/src/types/policies/ITCStorage.jl
@@ -67,7 +67,8 @@ function E4ST.modify_model!(pol::ITCStorage, config, data, model)
     nyr = get_num_years(data)
     storage = get_table(data, :storage)
 
-    name = Symbol("$(pol.name)_obj")
+    #name = Symbol("$(pol.name)_obj")
+    name = pol.name
     pcap_stor_inv_sim = model[:pcap_stor_inv_sim]::Vector
     model[name] = @expression(model,
         [yr_idx in 1:nyr],


### PR DESCRIPTION
this was a small change to make it more consistent with how the ITC is named in the objective function which makes it easier to test. If there is some reason to use the  _obj suffix let me know 