### PR TITLE
Add gen_filters to Crediting

### DIFF
--- a/src/io/util.jl
+++ b/src/io/util.jl
@@ -238,14 +238,13 @@ export get_row_idxs
 Compares a single DataFrameRow to the pairs given and returns the true/false result of the comparison. 
 """
 function row_comparison(row::DataFrameRow, pairs)
-    result = true # start as true and will turn false if any of the pairs isn't met
     for pair in pairs
         key, val = pair
         v = row[key]
         comp = comparison(val, v)
-        result = result && comp(v)
+        comp(v) == false && return false
     end
-    return result
+    return true
 end
 export row_comparison
 

--- a/src/io/util.jl
+++ b/src/io/util.jl
@@ -232,6 +232,23 @@ function get_row_idxs(table, pair::Pair)
 end
 export get_row_idxs
 
+"""
+    row_comparison(row::DataFrameRow, pairs)
+
+Compares a single DataFrameRow to the pairs given and returns the true/false result of the comparison. 
+"""
+function row_comparison(row::DataFrameRow, pairs)
+    result = true # start as true and will turn false if any of the pairs isn't met
+    for pair in pairs
+        key, val = pair
+        v = row[key]
+        comp = comparison(val, v)
+        result = result && comp(v)
+    end
+    return result
+end
+export row_comparison
+
 
 """
     comparison(value, v) -> comp::Function
@@ -248,6 +265,10 @@ function comparison(value, v::AbstractVector)
     comparison(value, eltype(v))
 end
 export comparison
+
+function comparison(value, v::Any)
+    comparison(value, eltype(v))
+end
 
 function comparison(value::Function, ::Type)
     return value

--- a/src/types/Crediting.jl
+++ b/src/types/Crediting.jl
@@ -126,11 +126,11 @@ export CreditByBenchmark
 Returns the credit level based on the formula `max(1.0 - (gen_row[gen_col] / c.benchmark), 0.0)`. 
 """
 function get_credit(c::CreditByBenchmark, data, gen_row::DataFrameRow)
-    if row_comparison(gen_row, parse_comparisons(c.gen_filters)) # meets gen filters
-        gen_emis_rate = gen_row[c.gen_col]
+    gen_emis_rate = gen_row[c.gen_col]
+    if row_comparison(gen_row, parse_comparisons(c.gen_filters)) # meets gen filters   
         credit = min.(1.0, max.( 1.0 .- gen_emis_rate ./ c.benchmark, 0.0))
     else
-        credit = 0
+        credit = 0.0 .* gen_emis_rate
     end
     return credit
 end

--- a/test/config/config_3bus_ces.yml
+++ b/test/config/config_3bus_ces.yml
@@ -5,7 +5,9 @@ mods:
     type: "CES"
     crediting: 
       type: "CreditByBenchmark"
-      benchmark: 0.5
+      benchmark: 0.8
+      gen_filters: 
+        genfuel: "[solar, wind, water, water, biomass, hydrogen, nuclear, geothermal, other]"
     gen_filters:
       nation: "archenland"
     load_targets:

--- a/test/testpoltypes.jl
+++ b/test/testpoltypes.jl
@@ -439,6 +439,9 @@
 
                 @test ~any(credit -> any(x -> x > (1.0) || x < (0.0), credit), gen[!, :example_ces])
 
+                fossil_gen = get_subtable(gen, :genfuel => ["coal", "ng", "oil"])
+                @test ~any(credit -> any(x -> x != 0, credit), fossil_gen[:, :example_ces])
+
             end
 
             @testset "Adding CES to model" begin


### PR DESCRIPTION
Adding gen_filters option to Crediting so that we can filter out some gentypes (mostly fossil gen which can't receive CES crediting in many states. Addresses #226. Had to add some comparison functions to work with comparing against a single row instead of a whole table so I'm open for any suggestions on how to improve those functions. 