### PR TITLE
update results combining to replace missing values and keep those rows

### DIFF
--- a/src/post/post.jl
+++ b/src/post/post.jl
@@ -174,10 +174,13 @@ function join_sim_tables(post_mod_data, keep_col; replace_missing = 0.)
     for (sim_name, df) in post_mod_data
         sim_name === first_sim_name && continue
         res = outerjoin(res, df, on=joining_cols, matchmissing=:equal)
-        res .= ifelse.(ismissing.(res), replace_missing, res) #replaces all missing values in res with the replace_missing kw value
+        replace!(res[!, keep_col], missing => replace_missing)
         rename!(res, keep_col=>sim_name)
     end
 
+    # Call dropmissing to change the types from Vector{Union{Missing, etc}}
+    dropmissing!(res)
+    
     return res
 end
 export join_sim_tables

--- a/src/post/post.jl
+++ b/src/post/post.jl
@@ -162,8 +162,10 @@ end
     join_sim_tables(post_mod_data, keep_col)
 
 Joins tables for multiple sims stored in `post_mod_data`, with `keep_col` as the column to keep, and the remaining columns as the joining columns.
+
+* `replace_missing` - replaces missing values in res after the tables are joined with the value of the kw arg. To keep missing values, set replace_missing = missing. 
 """
-function join_sim_tables(post_mod_data, keep_col)
+function join_sim_tables(post_mod_data, keep_col; replace_missing = 0.)
     first_sim_name = first(keys(post_mod_data))
     res = deepcopy(post_mod_data[first_sim_name])
     joining_cols = filter!(!=(string(keep_col)), names(res))
@@ -171,7 +173,8 @@ function join_sim_tables(post_mod_data, keep_col)
 
     for (sim_name, df) in post_mod_data
         sim_name === first_sim_name && continue
-        leftjoin!(res, df, on=joining_cols, matchmissing=:equal)
+        res = outerjoin(res, df, on=joining_cols, matchmissing=:equal)
+        res .= ifelse.(ismissing.(res), replace_missing, res) #replaces all missing values in res with the replace_missing kw value
         rename!(res, keep_col=>sim_name)
     end
 

--- a/src/post/post.jl
+++ b/src/post/post.jl
@@ -174,13 +174,16 @@ function join_sim_tables(post_mod_data, keep_col; replace_missing = 0.)
     for (sim_name, df) in post_mod_data
         sim_name === first_sim_name && continue
         res = outerjoin(res, df, on=joining_cols, matchmissing=:equal)
-        replace!(res[!, keep_col], missing => replace_missing)
         rename!(res, keep_col=>sim_name)
     end
 
     # Call dropmissing to change the types from Vector{Union{Missing, etc}}
+    for col in names(res)
+        replace!(res[!, col], missing=>replace_missing)
+    end
+
     dropmissing!(res)
-    
+
     return res
 end
 export join_sim_tables

--- a/src/types/modifications/AggregationTemplate.jl
+++ b/src/types/modifications/AggregationTemplate.jl
@@ -96,21 +96,8 @@ function extract_results(m::AggregationTemplate, config, data)
 end
 
 function combine_results(m::AggregationTemplate, post_config, post_data)
-    sim_names = get_sim_names(post_config)
     
-    # Create result DataFrame
-    first_sim_name = first(sim_names)
-    res = deepcopy(post_data[first_sim_name])
-    joining_cols = filter!(!=(:value), propertynames(res))
-    rename!(res, :value=>first_sim_name)
-
-    
-    for sim_name in sim_names
-        sim_name === first(sim_names) && continue
-        df = post_data[sim_name]
-        leftjoin!(res, df, on=joining_cols, matchmissing=:equal)
-        rename!(res, :value=>sim_name)
-    end
+    res = join_sim_tables(post_data, :value)
 
     CSV.write(get_out_path(post_config, "$(m.name)_combined.csv"), res)
 end

--- a/src/types/modifications/YearlyTable.jl
+++ b/src/types/modifications/YearlyTable.jl
@@ -20,7 +20,7 @@ struct YearlyTable{G,H} <: Modification
 end
 export YearlyTable
 function YearlyTable(;name, table_name, groupby = Symbol[], group_hours_by = Symbol[])
-    if groupby == ":"
+    if groupby == ":" || groupby == "Colon()"
         groupby = (:)
     end
     return YearlyTable(Symbol(name), Symbol(table_name), groupby, group_hours_by)


### PR DESCRIPTION
Previously we used a left join which would remove any results that weren't in the base case. This is a problem if you don't have a certain gentype in the base case but do in other cases or something along those lines. We now use an outerjoin and replace missing values with a default of 0 (which can be specified as something else if desired). 