### PR TITLE
RFF-E4ST documentation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -48,7 +48,7 @@ makedocs(
             "Retrofits" => "types/modifications/retrofits.md",
             "Interface Limits" => "types/modifications/interface-limits.md",
         ],
-        
+        "RFF-E4ST"=>"rff-e4st.md",        
     ],
     # TODO: Comment out format line before deploying, this is only for testing locally
     format = Documenter.HTML(

--- a/docs/src/rff-e4st.md
+++ b/docs/src/rff-e4st.md
@@ -1,0 +1,34 @@
+RFF-E4ST
+========
+Resources for the Future (RFF), the main organization responsible for developing and maintaining E4ST.jl, has a carefully curated a set of inputs and assumptions that we use in our analyses.  With the E4ST.jl writing process, we have tried to make our model straight-forward and easy to pick up and use for other modelers.  However, many of the inputs we use for our analyses are proprietary and require a license.  There are also custom Modifications that are still in development, or project-specific that we have chosen not to release in E4ST.jl.  If you are interested in using our inputs (possibly necessitating a licensing fee paid to the data providers), please contact Dan Shawhan at shawhan@rff.org.  This page provides an overview of the inputs and assumptions we use for our analyses.
+
+```@contents
+Pages = ["rff-e4st.md"]
+```
+
+# Grid
+Coming Soon!
+# Generation
+Coming Soon!
+# Hours Representation
+Coming Soon!
+## Existing Generation
+Coming Soon!
+## New Generation
+Coming Soon!
+### Costs
+Coming Soon!
+### Locations
+Coming Soon!
+## Storage
+Coming Soon!
+## Resource Values
+Coming Soon!
+## Carbon Sequestration Market
+Coming Soon!
+# Reserve Requirements
+Coming Soon!
+# Policies
+Coming Soon!
+# Air Pollution Model
+Coming Soon!


### PR DESCRIPTION
Not yet complete, but this PR is for getting RFF-E4ST documentation ready to push out.  
The URL of this will be:
https://e4st-dev.github.io/E4ST.jl/dev/rff-e4st.html

Or, if we decide to split into multiple web pages, it will be something different.  But for now, I think one run-on document should suffice.
