### PR TITLE
Feat 309 dcline one way

### DIFF
--- a/src/io/config.jl
+++ b/src/io/config.jl
@@ -75,6 +75,7 @@ function summarize_config()
         (:error_if_zero_cost, false, true, "Whether or not to throw an error if there are generators with zero costs over the entire year.  If set to equal false, it will throw a warning message rather than an error."),
         (:error_if_voltage_angle_at_bound, false, true, "Whether or not to throw an error if there is a voltage angle within 1% of the voltage angle bounds."),
         (:voltage_angle_bound, false, 1e3, "The magnitude of the bounds to use for the voltage angle, θ, for each bus.  It helps numerical stability to keep tight bounds, but these bounds should never be binding.  The simulation will throw an error if the bounds are too tight."),
+        (:voltage_angle_diff_max, false, 0, "The magnitude of the maximum allowable voltage angle diff, to be applied only to the branches with no limit (i.e. pflow_max = 0).  Will be applied in `cons_branch_pflow_pos` and `cons_branch_pflow_neg`, and is reflected in `get_pflow_branch_max`.  Set to 0 to have no effect."),
         (:require_optimal, false, true, "Whether or not to require whether or not the model is solved to optimality.  If set to true and the optimizer terminates with a suboptimal termination status, [`run_e4st`](@ref) returns after optimizing, without parsing results, etc."),
         (:model_string_names, false, false, "Whether or not to allow the model to have string names.  Defaults to `false` for memory savings.  Can be helpful to turn on for debugging, especially if you are encountering an infeasible model"),
 

--- a/src/io/data.jl
+++ b/src/io/data.jl
@@ -1582,8 +1582,15 @@ export get_pcap_max
 
 Returns max power flow on a branch at a given time. 
 """
-function get_pflow_branch_max(data, branch_idx, year_idx, hour_idx) 
-    return get_table_num(data, :branch, :pflow_max, branch_idx, year_idx, hour_idx)
+function get_pflow_branch_max(data, branch_idx, year_idx, hour_idx)
+    pflow_branch = get_table_num(data, :branch, :pflow_max, branch_idx, year_idx, hour_idx)
+
+    voltage_angle_diff_max = data[:voltage_angle_diff_max] |> Float64
+
+    if pflow_branch == 0.0 && voltage_angle_diff_max > 0
+        return voltage_angle_diff_max / get_table_num(data, :branch, :x, branch_idx, year_idx, hour_idx)
+    end
+    return pflow_branch
 end
 export get_pflow_branch_max
 

--- a/src/io/data.jl
+++ b/src/io/data.jl
@@ -656,12 +656,16 @@ function setup_table!(config, data, ::Val{:branch})
 
     # Add connected branches, connected buses.
     connected_branch_idxs = [Int64[] for _ in 1:nrow(bus)]
+    connected_bus_idxs = [Int64[] for _ in 1:nrow(bus)]
     add_table_col!(data, :bus, :connected_branch_idxs, connected_branch_idxs, NA, "A vector containing the indices of the branches connected to this bus")
+    add_table_col!(data, :bus, :connected_bus_idxs, connected_bus_idxs, NA, "A vector containing the indices of the bus connected to this bus")
     for (br_idx, br) in enumerate(eachrow(branch))
         f_bus_idx = br.f_bus_idx::Int64
         t_bus_idx = br.t_bus_idx::Int64
         push!(bus[f_bus_idx, :connected_branch_idxs], br_idx)
         push!(bus[t_bus_idx, :connected_branch_idxs], -br_idx)
+        push!(bus[f_bus_idx, :connected_bus_idxs], t_bus_idx)
+        push!(bus[t_bus_idx, :connected_bus_idxs], f_bus_idx)
     end
     return
 end

--- a/src/model/dcopf.jl
+++ b/src/model/dcopf.jl
@@ -32,9 +32,13 @@ function setup_dcopf!(config, data, model)
     @variable(model, 
         θ_bus[bus_idx in 1:nbus, year_idx in 1:nyear, hour_idx in 1:nhour], 
         start=0.0,
-        lower_bound = -θ_bound,
-        upper_bound =  θ_bound
     )
+
+    # Set a bound if applicable
+    if θ_bound > 0
+        set_lower_bound.(θ_bus, -θ_bound)
+        set_upper_bound.(θ_bus, θ_bound)
+    end
 
     # Capacity
     @variable(model, 

--- a/src/types/Containers.jl
+++ b/src/types/Containers.jl
@@ -148,18 +148,17 @@ end
 function Base.convert(::Type{<:OriginalContainer{N, D, C}}, x::ByNothing) where {N,D,C}
     return OriginalContainer(x.v, convert(C, x))
 end
-function Base.convert(::Type{ByNothing}, c::ByYear)
-    if length(c.v) == 1
-        return ByNothing(c.v[1])
+function Base.convert(::Type{ByNothing}, c::C) where {C<:Container}
+    if all(==(1), size(c))
+        return ByNothing(c[1,1])
     end
-    error("To convert from ByYear to ByNothing, it must have only a single value")
+    error("To convert from $C to ByNothing, it must have only a single value")
 end
 function Base.convert(::Type{Float64}, c::Container)
-    if length(c) == 1
-        return c[1]
-    else
-        error("Cannot convert Container of length $(length(c)) to Float64")
+    if all(==(1), size(c))
+        return c[1,1]
     end
+    error("Cannot convert Container of size $(size(c)) to Float64")
 end
 
 function Base.convert(::Type{<:Container}, c::Float64)

--- a/test/data/3bus/dc_line.csv
+++ b/test/data/3bus/dc_line.csv
@@ -1,2 +1,2 @@
-f_bus_idx,t_bus_idx,status,pflow_max
-1,3,1,0.1
+f_bus_idx,t_bus_idx,status,pflow_max,pflow_max_reverse
+1,3,1,0.1,0.1


### PR DESCRIPTION
Closes #309.  Makes it so that DC Lines are by default one-directional.  Contains a couple of other miscellaneous fixes as well.